### PR TITLE
Updating .sol contracts to match latest version (v0.4.25)

### DIFF
--- a/solidity/DieselPrice.sol
+++ b/solidity/DieselPrice.sol
@@ -4,31 +4,30 @@
     This contract keeps in storage a reference
     to the Diesel Price in USD
 */
-pragma solidity ^0.4.0;
-
-import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
-
+pragma solidity ^0.4.25;
+import "https://raw.githubusercontent.com/oraclize/ethereum-api/master/oraclizeAPI_0.4.25.sol";
 
 contract DieselPrice is usingOraclize {
 
-    uint public dieselPriceUSD;
+    uint256 public dieselPriceUSD;
 
-    event NewOraclizeQuery(string description);
-    event NewDieselPrice(string price);
+    event NewOraclizeQuery(string _description);
+    event NewDieselPrice(string _price);
 
-    function DieselPrice() public {
+    constructor() public payable {
         update(); // first check at contract creation
     }
 
-    function __callback(bytes32 myid, string result) public {
+    function __callback(bytes32 _myid, string _result) public {
         if (msg.sender != oraclize_cbAddress()) revert();
-        NewDieselPrice(result);
-        dieselPriceUSD = parseInt(result, 2); // let's save it as $ cents
-        // do something with the USD Diesel price
+        emit NewDieselPrice(_result);
+        dieselPriceUSD = parseInt(_result, 2); // Let's save it as $ cents (2 decimal places)
+        // Do something with the USD Diesel price
     }
 
     function update() public payable {
-        NewOraclizeQuery("Oraclize query was sent, standing by for the answer..");
+        emit NewOraclizeQuery("Oraclize query was sent, standing by for the answer...");
         oraclize_query("URL", "xml(https://www.fueleconomy.gov/ws/rest/fuelprices).fuelPrices.diesel");
     }
+    
 }

--- a/solidity/KrakenPriceTicker.sol
+++ b/solidity/KrakenPriceTicker.sol
@@ -4,36 +4,36 @@
    This contract keeps in storage an updated ETH/XBT price,
    which is updated every ~60 seconds.
 */
-pragma solidity ^0.4.0;
-
-import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
-
+pragma solidity ^0.4.25;
+import "https://raw.githubusercontent.com/oraclize/ethereum-api/master/oraclizeAPI_0.4.25.sol";
 
 contract KrakenPriceTicker is usingOraclize {
 
     string public priceETHXBT;
 
-    event NewOraclizeQuery(string description);
-    event NewKrakenPriceTicker(string price);
+    event NewOraclizeQuery(string _description);
+    event NewKrakenPriceTicker(string _price);
 
-    function KrakenPriceTicker() public {
+    constructor() public payable {
         oraclize_setProof(proofType_Android | proofStorage_IPFS);
         update();
     }
 
-    function __callback(bytes32 myid, string result, bytes proof) public {
+    function __callback(bytes32 _myid, string _result, bytes _proof) public {
         if (msg.sender != oraclize_cbAddress()) revert();
-        priceETHXBT = result;
-        NewKrakenPriceTicker(priceETHXBT);
+        priceETHXBT = _result;
+        emit NewKrakenPriceTicker(priceETHXBT);
         update();
     }
 
     function update() public payable {
         if (oraclize_getPrice("URL") > this.balance) {
-            NewOraclizeQuery("Oraclize query was NOT sent, please add some ETH to cover for the query fee");
+            emit NewOraclizeQuery("Oraclize query was NOT sent, please add some ETH to cover for the query fee");
         } else {
-            NewOraclizeQuery("Oraclize query was sent, standing by for the answer..");
+            emit NewOraclizeQuery("Oraclize query was sent, standing by for the answer...");
             oraclize_query(60, "URL", "json(https://api.kraken.com/0/public/Ticker?pair=ETHXBT).result.XETHXXBT.c.0");
         }
     }
 }
+
+

--- a/solidity/Swarm.sol
+++ b/solidity/Swarm.sol
@@ -1,31 +1,30 @@
 /*
-   swarm example
+   Swarm example
 */
 
-
-pragma solidity ^0.4.0;
-import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
+pragma solidity ^0.4.25;
+import "https://raw.githubusercontent.com/oraclize/ethereum-api/master/oraclizeAPI_0.4.25.sol";
 
 contract Swarm is usingOraclize {
     
     string public swarmContent;
     
-    event newOraclizeQuery(string description);
-    event newSwarmContent(string swarmContent);
+    event newOraclizeQuery(string _description);
+    event newSwarmContent(string _swarmContent);
 
-    function Swarm() {
+    constructor() public payable {
         update();
     }
     
-    function __callback(bytes32 myid, string result) {
-        if (msg.sender != oraclize_cbAddress()) throw;
-        swarmContent = result;
-        newSwarmContent(result);
-        // do something with the swarm content..
+    function __callback(bytes32 _myid, string _result) {
+        if (msg.sender != oraclize_cbAddress()) revert();
+        swarmContent = _result;
+        emit newSwarmContent(_result);
+        // Do something with the Swarm content
     }
     
-    function update() payable {
-        newOraclizeQuery("Oraclize query was sent, standing by for the answer..");
+    function update() public payable {
+        emit newOraclizeQuery("Oraclize query was sent, standing by for the answer...");
         oraclize_query("swarm", "1dad37bcc272aa31d45128992be575820bececb13dd42c4cc87e4b6269067464");
     }
     

--- a/solidity/WolframAlpha.sol
+++ b/solidity/WolframAlpha.sol
@@ -1,33 +1,31 @@
 /*
     WolframAlpha example
 
-    This contract sends a temperature measure request to WolframAlpha
+    This contract sends a temperature measurement request to WolframAlpha
 */
-pragma solidity ^0.4.0;
-
-import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
-
+pragma solidity ^0.4.25;
+import "https://raw.githubusercontent.com/oraclize/ethereum-api/master/oraclizeAPI_0.4.25.sol";
 
 contract WolframAlpha is usingOraclize {
 
     string public temperature;
 
-    event NewOraclizeQuery(string description);
-    event NewTemperatureMeasure(string temperature);
+    event NewOraclizeQuery(string _description);
+    event NewTemperatureMeasure(string _temperature);
 
-    function WolframAlpha() public {
+    constructor() public payable {
         update();
     }
 
-    function __callback(bytes32 myid, string result) public {
+    function __callback(bytes32 _myid, string _result) public {
         if (msg.sender != oraclize_cbAddress()) revert();
-        temperature = result;
-        NewTemperatureMeasure(temperature);
-        // do something with the temperature measure..
+        temperature = _result;
+        emit NewTemperatureMeasure(temperature);
+        // Do something with the temperature measurement
     }
 
     function update() public payable {
-        NewOraclizeQuery("Oraclize query was sent, standing by for the answer..");
+        emit NewOraclizeQuery("Oraclize query was sent, standing by for the answer...");
         oraclize_query("WolframAlpha", "temperature in London");
     }
 }

--- a/solidity/YoutubeViews.sol
+++ b/solidity/YoutubeViews.sol
@@ -1,35 +1,33 @@
 /*
-    Youtube video views
+    Youtube Video Views
 
     This contract keeps in storage a views counter
     for a given Youtube video.
 */
 
-pragma solidity ^0.4.0;
-
-import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
-
+pragma solidity ^0.4.25;
+import "https://raw.githubusercontent.com/oraclize/ethereum-api/master/oraclizeAPI_0.4.25.sol";
 
 contract YoutubeViews is usingOraclize {
 
     string public viewsCount;
 
-    event NewOraclizeQuery(string description);
-    event NewYoutubeViewsCount(string views);
+    event NewOraclizeQuery(string _description);
+    event NewYoutubeViewsCount(string _views);
 
-    function YoutubeViews() public {
+    constructor() public payable {
         update();
     }
 
-    function __callback(bytes32 myid, string result) public {
+    function __callback(bytes32 _myid, string _result) public {
         if (msg.sender != oraclize_cbAddress()) revert();
-        viewsCount = result;
-        NewYoutubeViewsCount(viewsCount);
-        // do something with viewsCount. like tipping the author if viewsCount > X?
+        viewsCount = _result;
+        emit NewYoutubeViewsCount(viewsCount);
+        // Do something with viewsCount. Like tipping the author if viewsCount > x?
     }
 
     function update() public payable {
-        NewOraclizeQuery("Oraclize query was sent, standing by for the answer..");
+        emit NewOraclizeQuery("Oraclize query was sent, standing by for the answer...");
         oraclize_query("URL", 'html(https://www.youtube.com/watch?v=9bZkp7q19f0).xpath(//*[contains(@class, "watch-view-count")]/text())');
     }
 }


### PR DESCRIPTION
Hello,

I changed some of the deprecated syntax in these contracts, such as using the contract name in the constructor (the currently supported method is constructor()) and events utilizing the "emit" keyword. I also modified some of the parameter variable names by adding a leading underscore (_) in order to better separate public variables from local scope "internal" variables, making it easier to read. The contracts are also now payable, which allows for funding contracts which may need more ETH to pay for Oraclize requests. 

In general, I tried to improve readability and keep it updated for those who may be wanting to use these examples with the current, updated v0.4.25.

Thanks! 