### PR TITLE
fix(ethereum-examples): edit proof types in readme

### DIFF
--- a/solidity/README.md
+++ b/solidity/README.md
@@ -8,9 +8,9 @@ Alternatively, if you prefer to develop locally, browse into the __`truffle-exam
 
 ***
 
-### :black_nib: __Notes__
+### :black_nib: __Features!__
 
-The following is a list of the features you will find amongst the examples, along with link to the pertinent example(s):
+The following is a list of the features you can find amongst the samples in this repo, along with links to the pertinent example(s):
 
 * Sending simple __URL Queries!__ [#1](./DieselPrice.sol).
 * Scheduling a query for a __future date__! [#1](./KrakenPriceTicker.sol).
@@ -34,4 +34,4 @@ __Coming Soon!__
 
 ### :loudspeaker: __Support__
 
-If you need any help working with the examples here, you can get timely support in the [__Oraclize Gitter__](https://gitter.im/oraclize) channel.
+If you need any help when working with the examples here, you can always get timely support in the [__Oraclize Gitter channel here__](https://gitter.im/oraclize)!

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -12,16 +12,16 @@ Alternatively, if you prefer to develop locally, browse into the __`truffle-exam
 
 The following is a list of the features you will find amongst the examples, along with link to the pertinent example(s):
 
-* Sending simple __URL Queries!__ ([Example #1](./DieselPrice.sol))
-* Scheduling a query for a __future date__! ([Example #1](./KrakenPriceTicker.sol))
-* Sending calls __recursively__! ([Example #1](./KrakenPriceTicker.sol))
-* Requesting a __TLSNotary__ authenticity __proof!__ ([Example #1](./computation-datasource/delegated-math/DelegatedMath.sol))
-* Requesting an __Android__ authenticity __proof!__ ([Example #1](./KrakenPriceTicker.sol))
-* Leveraging __JSONPATH__ parsing helpers! ([Example #1](./KrakenPriceTicker.sol))
-* Using __IPFS__ for proof storage! ([Example #1](./UrlRequests.sol))
-* Leveraging __XPATH__ parsing helpers! ([Example #1](./DieselPricePeg.sol), [example #2](./YoutubeViews.sol))
-* Using the __computation datasouce__! ([Example #1](./computation-datasource/url-requests/urlRequests.sol), [example #2](./computation-datasource/streamr/StreamrTweetsCounter.sol))
-* Using the __WolframAlpha__ datasource! ([Example #1](./WolframAlpha.sol))
+* Sending simple __URL Queries!__ [#1](./DieselPrice.sol).
+* Scheduling a query for a __future date__! [#1](./KrakenPriceTicker.sol).
+* Sending calls __recursively__! [#1](./KrakenPriceTicker.sol).
+* Requesting a __TLSNotary__ authenticity __proof!__ [#1](./computation-datasource/delegated-math/DelegatedMath.sol), [#2](./compuation-datasource/paypal/PaypalExample.sol), & [#3](./contracts/GasPriceOracle.sol).
+* Requesting an __Android__ authenticity __proof!__ [#1](./KrakenPriceTicker.sol) & [#2](./computation-datasource/url-requests/UrlRequests.sol).
+* Leveraging __JSONPATH__ parsing helpers! [#1](./KrakenPriceTicker.sol).
+* Using __IPFS__ for proof storage! [#1](./UrlRequests.sol), [#2](./KrakenPriceTicker.sol) & [#3](./compuation-datasource/delegated-math/DelegatedMath.sol).
+* Leveraging __XPATH__ parsing helpers! [#1](./DieselPricePeg.sol) & [#2](./YoutubeViews.sol).
+* Using the __computation datasouce__! [#1](./computation-datasource/url-requests/urlRequests.sol), [#2](./computation-datasource/streamr/StreamrTweetsCounter.sol) & [#3](./computation-datasource/bitcoin/BitcoinBalanceExample.sol).
+* Using the __WolframAlpha__ datasource! [#1](./WolframAlpha.sol).
 
 __Coming Soon!__
 

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -10,17 +10,18 @@ Alternatively, if you prefer to develop locally, browse into the __`truffle-exam
 
 ### :black_nib: __Notes__
 
-This is a list of the features you will find amongst the examples, along with a reference to the relevant example:
+The following is a list of the features you will find amongst the examples, along with link to the pertinent example(s):
 
-* Sending simple __URL Queries!__ [#1](./DieselPrice.sol)
-* Scheduling a query for a __future date__! [#1](./KrakenPriceTicker.sol)
-* Sending calls __recursively__! [#1](./KrakenPriceTicker.sol)
-* Requesting a __TLSNotary__ authenticity __proof!__ [#1](./computation-datasource/delegated-math/DelegatedMath.sol)
-* Requesting an __Android__ authenticity __proof!__ [#1](./KrakenPriceTicker.sol)
-* Leveraging __JSONPATH__ parsing helpers! [#1](./KrakenPriceTicker.sol)
-* Leveraging __XPATH__ parsing helpers! [#1](./DieselPricePeg.sol)  [#2](./YoutubeViews.sol)
-* Using the __computation datasouce__! [#1](./computation-datasource/url-requests/urlRequests.sol) [#2](./computation-datasource/streamr/StreamrTweetsCounter.sol)
-* Using the __WolframAlpha__ datasource! [#1](./WolframAlpha.sol)
+* Sending simple __URL Queries!__ ([Example #1](./DieselPrice.sol))
+* Scheduling a query for a __future date__! ([Example #1](./KrakenPriceTicker.sol))
+* Sending calls __recursively__! ([Example #1](./KrakenPriceTicker.sol))
+* Requesting a __TLSNotary__ authenticity __proof!__ ([Example #1](./computation-datasource/delegated-math/DelegatedMath.sol))
+* Requesting an __Android__ authenticity __proof!__ ([Example #1](./KrakenPriceTicker.sol))
+* Leveraging __JSONPATH__ parsing helpers! ([Example #1](./KrakenPriceTicker.sol))
+* Using __IPFS__ for proof storage! ([Example #1](./UrlRequests.sol))
+* Leveraging __XPATH__ parsing helpers! ([Example #1](./DieselPricePeg.sol), [example #2](./YoutubeViews.sol))
+* Using the __computation datasouce__! ([Example #1](./computation-datasource/url-requests/urlRequests.sol), [example #2](./computation-datasource/streamr/StreamrTweetsCounter.sol))
+* Using the __WolframAlpha__ datasource! ([Example #1](./WolframAlpha.sol))
 
 __Coming Soon!__
 

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -16,6 +16,7 @@ This is a list of the features you will find amongst the examples, along with a 
 * Scheduling a query for a __future date__! [#1](./KrakenPriceTicker.sol)
 * Sending calls __recursively__! [#1](./KrakenPriceTicker.sol)
 * Requesting a __TLSNotary__ authenticity __proof!__ [#1](./computation-datasource/delegated-math/DelegatedMath.sol)
+* Requesting an __Android__ authenticity __proof!__ [#1](./KrakenPriceTicker.sol)
 * Leveraging __JSONPATH__ parsing helpers! [#1](./KrakenPriceTicker.sol)
 * Leveraging __XPATH__ parsing helpers! [#1](./DieselPricePeg.sol)  [#2](./YoutubeViews.sol)
 * Using the __computation datasouce__! [#1](./computation-datasource/url-requests/urlRequests.sol) [#2](./computation-datasource/streamr/StreamrTweetsCounter.sol)

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -15,7 +15,7 @@ This is a list of the features you will find amongst the examples, along with a 
 * Sending simple __URL Queries!__ [#1](./DieselPrice.sol)
 * Scheduling a query for a __future date__! [#1](./KrakenPriceTicker.sol)
 * Sending calls __recursively__! [#1](./KrakenPriceTicker.sol)
-* Requesting __TLSNotary__ authenticity __proofs!__ [#1](./KrakenPriceTicker.sol)
+* Requesting a __TLSNotary__ authenticity __proof!__ [#1](./computation-datasource/delegated-math/DelegatedMath.sol)
 * Leveraging __JSONPATH__ parsing helpers! [#1](./KrakenPriceTicker.sol)
 * Leveraging __XPATH__ parsing helpers! [#1](./DieselPricePeg.sol)  [#2](./YoutubeViews.sol)
 * Using the __computation datasouce__! [#1](./computation-datasource/url-requests/urlRequests.sol) [#2](./computation-datasource/streamr/StreamrTweetsCounter.sol)


### PR DESCRIPTION
...per title.

Also:

- added more examples for each wherever applicable.
- tweaked the wording in a few places.

__Note:__

As has happened before when I used images in `README.md`s, the links to the various examples don't seem to work. IIRC the relative links only work properly once merged in master.