### PR TITLE
fix: truffle config dev port

### DIFF
--- a/solidity/truffle-examples/bitcoin-balance/truffle.js
+++ b/solidity/truffle-examples/bitcoin-balance/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }

--- a/solidity/truffle-examples/delegated-math/truffle.js
+++ b/solidity/truffle-examples/delegated-math/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }

--- a/solidity/truffle-examples/diesel-price/truffle.js
+++ b/solidity/truffle-examples/diesel-price/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }

--- a/solidity/truffle-examples/kraken-price-ticker/truffle.js
+++ b/solidity/truffle-examples/kraken-price-ticker/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }

--- a/solidity/truffle-examples/random-datasource/truffle.js
+++ b/solidity/truffle-examples/random-datasource/truffle.js
@@ -13,7 +13,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
 	},

--- a/solidity/truffle-examples/streamr/truffle.js
+++ b/solidity/truffle-examples/streamr/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }

--- a/solidity/truffle-examples/url-requests/truffle.js
+++ b/solidity/truffle-examples/url-requests/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }

--- a/solidity/truffle-examples/wolfram-alpha/truffle.js
+++ b/solidity/truffle-examples/wolfram-alpha/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }

--- a/solidity/truffle-examples/youtube-views/truffle.js
+++ b/solidity/truffle-examples/youtube-views/truffle.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 9545,
       network_id: "*",
       websockets: true
     }


### PR DESCRIPTION
fixes config to reflect hardcoded 9545 port used across truffle dev console and the associated tests (needed by `truffle test` in case of using ganache).