### PR TITLE
feat(truffle-url-req): improve tests to rm inconsistent outcomes

### DIFF
--- a/solidity/truffle-examples/url-requests/test/url-requests-tests.js
+++ b/solidity/truffle-examples/url-requests/test/url-requests-tests.js
@@ -3,13 +3,14 @@ const {waitForEvent} = require('./utils')
 const urlRequests = artifacts.require('./UrlRequests.sol')
 const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://localhost:9545'))
 
-contract('Oraclize Example using Truffle', async accounts => {
+contract('Oraclize Example using Truffle', async ([ ACCOUNT_ZERO, ...accounts ]) => {
 
   describe("URL Requests Tests", async () => {
 
-    const gasAmt  = 3e6
-    const addr = accounts[0]
-    const urlReq = new Array(5).fill()
+    const GAS_AMOUNT = 3e6
+    const URL_REQUEST_CONTRACTS = new Array(5).fill()
+    const QUERY_SENT_STRING = 'Oraclize query was sent, standing by for the answer...'
+    const QUERY_NOT_SENT_STRING = 'Oraclize query was NOT sent, please add some ETH to cover for the query fee'
 
     it('Should log a new query upon a request for custom headers', async () => {
       const { contract } = await urlRequests.new()
@@ -17,18 +18,17 @@ contract('Oraclize Example using Truffle', async accounts => {
         contract._jsonInterface,
         contract._address
       )
-      urlReq[0] = { methods, events }
+      URL_REQUEST_CONTRACTS[0] = { methods, events }
       const { events: txEvents } = await methods
         .requestCustomHeaders()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = txEvents.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was sent, standing by for the answer...',
-        'Oraclize query incorrectly logged!'
+        QUERY_SENT_STRING,
       )
     })
 
@@ -38,18 +38,17 @@ contract('Oraclize Example using Truffle', async accounts => {
         contract._jsonInterface,
         contract._address
       )
-      urlReq[1] = { methods, events }
+      URL_REQUEST_CONTRACTS[1] = { methods, events }
       const { events: txEvents } = await methods
         .requestBasicAuth()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = txEvents.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
-      description,
-        'Oraclize query was sent, standing by for the answer...',
-        'Oraclize query incorrectly logged!'
+        description,
+        QUERY_SENT_STRING,
       )
     })
 
@@ -59,18 +58,17 @@ contract('Oraclize Example using Truffle', async accounts => {
         contract._jsonInterface,
         contract._address
       )
-      urlReq[2] = { methods, events }
+      URL_REQUEST_CONTRACTS[2] = { methods, events }
       const { events: txEvents } = await methods
         .requestPost()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = txEvents.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was sent, standing by for the answer...',
-        'Oraclize query incorrectly logged!'
+        QUERY_SENT_STRING,
       )
     })
 
@@ -80,18 +78,17 @@ contract('Oraclize Example using Truffle', async accounts => {
         contract._jsonInterface,
         contract._address
       )
-      urlReq[3] = { methods, events }
+      URL_REQUEST_CONTRACTS[3] = { methods, events }
       const { events: txEvents } = await methods
         .requestPut()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = txEvents.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
       description,
-        'Oraclize query was sent, standing by for the answer...',
-        'Oraclize query incorrectly logged!'
+        QUERY_SENT_STRING,
       )
     })
 
@@ -101,228 +98,176 @@ contract('Oraclize Example using Truffle', async accounts => {
         contract._jsonInterface,
         contract._address
       )
-      urlReq[4] = { methods, events }
+      URL_REQUEST_CONTRACTS[4] = { methods, events }
       const { events: txEvents } = await methods
         .requestCookies()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = txEvents.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was sent, standing by for the answer...',
-        'Oraclize query incorrectly logged!'
+        QUERY_SENT_STRING,
       )
     })
 
     it('Should log a failed second request for custom headers due to lack of funds', async () => {
-      const { events } = await urlReq[0]
+      const { events } = await URL_REQUEST_CONTRACTS[0]
         .methods
         .requestCustomHeaders()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = events.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was NOT sent, please add some ETH to cover for the query fee',
-        'Oraclize query incorrectly logged!'
+        QUERY_NOT_SENT_STRING
       )
     })
 
     it('Should log a failed second basic auth request due to lack of funds', async () => {
-      const {events } = await urlReq[1]
+      const {events } = await URL_REQUEST_CONTRACTS[1]
         .methods
         .requestBasicAuth()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = events.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was NOT sent, please add some ETH to cover for the query fee',
-        'Oraclize query incorrectly logged!'
+        QUERY_NOT_SENT_STRING
       )
     })
 
     it('Should log a failed second POST request due to lack of funds', async () => {
-      const { events }  = await urlReq[2]
+      const { events }  = await URL_REQUEST_CONTRACTS[2]
         .methods
         .requestPost()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = events.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was NOT sent, please add some ETH to cover for the query fee',
-        'Oraclize query incorrectly logged!'
+        QUERY_NOT_SENT_STRING
       )
     })
 
     it('Should log a failed second PUT request due to lack of funds', async () => {
-      const { events } = await urlReq[3]
+      const { events } = await URL_REQUEST_CONTRACTS[3]
         .methods
         .requestPut()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = events.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was NOT sent, please add some ETH to cover for the query fee',
-        'Oraclize query incorrectly logged!'
+        QUERY_NOT_SENT_STRING
       )
     })
 
     it('Should log a failed second request for cookies due to lack of funds', async () => {
-      const { events } = await urlReq[4]
+      const { events } = await URL_REQUEST_CONTRACTS[4]
         .methods
         .requestCookies()
         .send({
-          from: addr,
-          gas: gasAmt
+          from: ACCOUNT_ZERO,
+          gas: GAS_AMOUNT
         })
       const description = events.LogNewOraclizeQuery.returnValues.description
       assert.strictEqual(
         description,
-        'Oraclize query was NOT sent, please add some ETH to cover for the query fee',
-        'Oraclize query incorrectly logged!'
+        QUERY_NOT_SENT_STRING
       )
     })
 
     it('Should emit result from request for custom headers', async () => {
       const {
-        returnValues: {
-          result
-        }
-      } = await waitForEvent(urlReq[0].events.LogResult)
+        returnValues: { result }
+      } = await waitForEvent(URL_REQUEST_CONTRACTS[0].events.LogResult)
       assert.isTrue(
         result.includes('"Accept-Encoding": "gzip, deflate"') &&
-        result.includes('"Content-Type": "json"'),
-        'Incorrect result from custom header request!'
+        result.includes('"Content-Type": "json"')
       )
     })
 
     it('Should emit result from basic auth request', async () => {
       const {
-        returnValues: {
-          result
-        }
-      } = await waitForEvent(urlReq[1].events.LogResult)
+        returnValues: { result }
+      } = await waitForEvent(URL_REQUEST_CONTRACTS[1].events.LogResult)
       const expRes = '{  \"authenticated\": true,   \"user\": \"myuser\"}'
       assert.strictEqual(
         expRes,
-        result,
-        'Incorrect result from basic auth request!'
+        result
       )
     })
 
     it('Should emit result from POST request', async () => {
+      const SUCCESS_STATUS_CODE = 200
+      const QUERIED_COUNTRY = "England"
+      const QUERIED_POSTCODE = "OX49 5NU"
       const {
-        returnValues: {
-          result
-        }
-      } = await waitForEvent(urlReq[2].events.LogResult)
-      const expRes = {
-        "status": 200,
-        "result": [{
-          "query": "OX49 5NU",
-          "result": {
-            "postcode": "OX49 5NU",
-            "quality": 1,
-            "eastings": 464447,
-            "northings": 195647,
-            "country": "England",
-            "nhs_ha": "South Central",
-            "longitude": -1.069752,
-            "latitude": 51.655929,
-            "european_electoral_region": "South East",
-            "primary_care_trust": "Oxfordshire",
-            "region": "South East",
-            "lsoa": "South Oxfordshire 011B",
-            "msoa": "South Oxfordshire 011",
-            "incode": "5NU",
-            "outcode": "OX49",
-            "parliamentary_constituency": "Henley",
-            "admin_district": "South Oxfordshire",
-            "parish": "Brightwell Baldwin",
-            "admin_county": "Oxfordshire",
-            "admin_ward": "Chalgrove",
-            "ccg": "NHS Oxfordshire",
-            "nuts": "Oxfordshire",
-            "codes": {
-              "admin_district": "E07000179",
-              "admin_county": "E10000025",
-              "admin_ward": "E05009735",
-              "parish": "E04008109",
-              "parliamentary_constituency": "E14000742",
-              "ccg": "E38000136",
-              "nuts": "UKJ14"
-            }
-          }
-        }]
-      }
+        returnValues: { result }
+      } = await waitForEvent(URL_REQUEST_CONTRACTS[2].events.LogResult)
+      const jsonParsedResult = JSON.parse(result)
       assert.strictEqual(
-        JSON.stringify(expRes).slice(0,85),
-        result.slice(0,85),
-        'Incorrect result from POST request!'
-      ) // Note: The long. & lat. can change hence the slice!
+        jsonParsedResult.status,
+        SUCCESS_STATUS_CODE
+      )
+      assert.strictEqual(
+        jsonParsedResult.result[0].result.country,
+        QUERIED_COUNTRY
+      )
+      assert.strictEqual(
+        jsonParsedResult.result[0].result.postcode,
+        QUERIED_POSTCODE
+      )
     })
 
     it('Should emit result from PUT request', async () => {
+      const EXPECTED_METHOD = "PUT"
+      const EXPECTED_KEY = "testing"
+      const EXPECTED_VALUE = "it works"
+      const EXPECTED_HEADERS = "gzip, deflate"
+      const EXPECTED_DATA_STRING = `{"${EXPECTED_KEY}": "${EXPECTED_VALUE}"}`
       const {
-        returnValues: {
-          result
-        }
-      } = await waitForEvent(urlReq[3].events.LogResult)
-      const expRes = {
-        "args": {},
-        "data": "{\"testing\": \"it works\"}",
-        "files": {},
-        "form": {},
-        "headers": {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip, deflate",
-          "Connection": "close",
-          "Content-Length": "23",
-          "Content-Type": "application/json",
-          "Host": "httpbin.org",
-          "User-Agent": "python-requests/2.19.1"
-        },
-        "json": {
-          "testing": "it works"
-        },
-        "method": "PUT",
-        "origin": "n/a",
-        "url": "http://httpbin.org/anything"
-      }
-      const expResSerialized = JSON.stringify(expRes)
-      const resDeserialized = JSON.parse(result)
-      const resSerialized = JSON.stringify(resDeserialized)
+        returnValues: { result }
+      } = await waitForEvent(URL_REQUEST_CONTRACTS[3].events.LogResult)
+      const jsonParsedResult = JSON.parse(result)
       assert.strictEqual(
-        expResSerialized.slice(0,50),
-        resSerialized.slice(0,50),
-        'Incorrect result from PUT request!'
+        jsonParsedResult.method,
+        EXPECTED_METHOD
+      )
+      assert.strictEqual(
+        jsonParsedResult.data,
+        EXPECTED_DATA_STRING
+      )
+      assert.strictEqual(
+        jsonParsedResult.headers["Accept-Encoding"],
+        EXPECTED_HEADERS
+      )
+      assert.strictEqual(
+        jsonParsedResult.json[EXPECTED_KEY],
+        EXPECTED_VALUE
       )
     })
 
     it('Should emit result from cookie request', async () => {
+      const EXPECTED_COOKIE_KEY = "thiscookie"
+      const EXPECTED_COOKIE_VALUE = "should be saved and visible :)"
       const {
-        returnValues: {
-          result
-        }
-      } = await waitForEvent(urlReq[4].events.LogResult)
-      const expRes = `{  "cookies": {    "thiscookie": "should be saved and visible :)"  }}`
+        returnValues: { result }
+      } = await waitForEvent(URL_REQUEST_CONTRACTS[4].events.LogResult)
+      const jsonParsedResult = JSON.parse(result)
       assert.strictEqual(
-        expRes,
-        result,
-        'Incorrect result from cookie request!'
+        jsonParsedResult.cookies[EXPECTED_COOKIE_KEY],
+        EXPECTED_COOKIE_VALUE
       )
     })
   })

--- a/solidity/truffle-examples/url-requests/test/url-requests-tests.js
+++ b/solidity/truffle-examples/url-requests/test/url-requests-tests.js
@@ -128,7 +128,7 @@ contract('Oraclize Example using Truffle', async ([ ACCOUNT_ZERO, ...accounts ])
     })
 
     it('Should log a failed second basic auth request due to lack of funds', async () => {
-      const {events } = await URL_REQUEST_CONTRACTS[1]
+      const { events } = await URL_REQUEST_CONTRACTS[1]
         .methods
         .requestBasicAuth()
         .send({


### PR DESCRIPTION
...per title.

Removed the hard-coded, large, expected results in favour of `JSON.parse`-ing the result and cherry picking from that `JSON` info bits and bobs to verify the result. 

So now there are no longer any weird slices of results in order to avoid the variable parts of the response, so hopefully all should be gravy & consistent for the CI going forward.