### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/solidity/KrakenPriceTicker.sol
+++ b/solidity/KrakenPriceTicker.sol
@@ -26,7 +26,7 @@ contract KrakenPriceTicker is usingProvable {
         require(msg.sender == provable_cbAddress());
         update(); // Recursively update the price stored in the contract...
         priceETHXBT = _result;
-        emit LogNewKrakenPriceTicker(priceETHXBT);
+        emit LogNewKrakenPriceTicker(_result);
     }
 
     function update()

--- a/solidity/WolframAlpha.sol
+++ b/solidity/WolframAlpha.sol
@@ -23,7 +23,7 @@ contract WolframAlpha is usingProvable {
     {
         require(msg.sender == provable_cbAddress());
         temperature = _result;
-        emit LogNewTemperatureMeasure(temperature);
+        emit LogNewTemperatureMeasure(_result);
         // Do something with the temperature measure...
     }
 

--- a/solidity/YoutubeViews.sol
+++ b/solidity/YoutubeViews.sol
@@ -23,7 +23,7 @@ contract YoutubeViews is usingProvable {
     {
         require(msg.sender == provable_cbAddress());
         viewsCount = _result;
-        emit LogYoutubeViewCount(viewsCount);
+        emit LogYoutubeViewCount(_result);
         // Do something with viewsCount, like tipping the author if viewsCount > X?
     }
 

--- a/solidity/truffle-examples/caller-pays-for-query/contracts/CallerPaysForQuery.sol
+++ b/solidity/truffle-examples/caller-pays-for-query/contracts/CallerPaysForQuery.sol
@@ -31,7 +31,7 @@ contract CallerPaysForQuery is usingProvable {
     {
         require(msg.sender == provable_cbAddress());
         ethPriceInUSD = _result;
-        emit LogNewEthPrice(ethPriceInUSD);
+        emit LogNewEthPrice(_result);
     }
 
     function getEthPriceInUSDViaProvable()

--- a/solidity/truffle-examples/encrypted-query/contracts/EncryptedQuery.sol
+++ b/solidity/truffle-examples/encrypted-query/contracts/EncryptedQuery.sol
@@ -25,7 +25,7 @@ contract EncryptedQuery is usingProvable {
         require(msg.sender == provable_cbAddress());
         update(); // Recursively update the status stored in the contract...
         requestStatus = _result;
-        emit LogNewRequestStatus(requestStatus);
+        emit LogNewRequestStatus(_result);
     }
 
     function update()

--- a/solidity/truffle-examples/kraken-price-ticker/contracts/KrakenPriceTicker.sol
+++ b/solidity/truffle-examples/kraken-price-ticker/contracts/KrakenPriceTicker.sol
@@ -26,7 +26,7 @@ contract KrakenPriceTicker is usingProvable {
         require(msg.sender == provable_cbAddress());
         update(); // Recursively update the price stored in the contract...
         priceETHXBT = _result;
-        emit LogNewKrakenPriceTicker(priceETHXBT);
+        emit LogNewKrakenPriceTicker(_result);
     }
 
     function update()

--- a/solidity/truffle-examples/wolfram-alpha/contracts/WolframAlpha.sol
+++ b/solidity/truffle-examples/wolfram-alpha/contracts/WolframAlpha.sol
@@ -23,7 +23,7 @@ contract WolframAlpha is usingProvable {
     {
         require(msg.sender == provable_cbAddress());
         temperature = _result;
-        emit LogNewTemperatureMeasure(temperature);
+        emit LogNewTemperatureMeasure(_result);
         // Do something with the temperature measure...
     }
 

--- a/solidity/truffle-examples/youtube-views/contracts/YoutubeViews.sol
+++ b/solidity/truffle-examples/youtube-views/contracts/YoutubeViews.sol
@@ -23,7 +23,7 @@ contract YoutubeViews is usingProvable {
     {
         require(msg.sender == provable_cbAddress());
         viewsCount = _result;
-        emit LogYoutubeViewCount(viewsCount);
+        emit LogYoutubeViewCount(_result);
         // Do something with viewsCount, like tipping the author if viewsCount > X?
     }
 


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.